### PR TITLE
Correctly purge vanished protocols

### DIFF
--- a/birdwatch
+++ b/birdwatch
@@ -46,8 +46,10 @@ class ProtocolHandler:
         self.protocol_log = {}
         self.touched = []
 
-    def new_session(self):
+    def update(self, protocols):
         self.touched = []
+        self.inject_protocols(protocols)
+        self.alert_for_changes()
 
     def inject_protocol(self, protocol):
         if type(protocol) is not Protocol:
@@ -84,7 +86,7 @@ class ProtocolHandler:
         for protocol in protocols:
             self.inject_protocol(protocol)
 
-    def get_changes(self):
+    def alert_for_changes(self):
         now_x = {}
         body = []
 
@@ -184,9 +186,7 @@ def watch_socket(socket_path, socket_alias, sigterm_handler):
                     proto = Protocol(proto_name, proto_type, proto_table, proto_state, proto_since, proto_info)
                     protocols.append(proto)
 
-            handler.new_session()
-            handler.inject_protocols(protocols)
-            handler.get_changes()
+            handler.update(protocols)
 
             for i in range(CHECK_INTERVAL):
                 if sigterm_handler.kill_now:

--- a/birdwatch
+++ b/birdwatch
@@ -40,11 +40,11 @@ class Protocol:
 class ProtocolHandler:
     def __init__(self, socket_alias):
         self.socket_alias = socket_alias
-        self.last_state = {}
-        self.last_alert_state = {}
-        self.alert_time = {}
-        self.protocol_log = {}
-        self.touched = []
+        self.last_state = {}  # protocol state after last update
+        self.last_alert_state = {}  # protocol state that was sent in the last alert
+        self.alert_time = {}  # time when an alert should be sent for this protocol
+        self.protocol_log = {}  # storage for actual Protocol object (to obtain detailed info later)
+        self.touched = []  # protocols that were present in last update
 
     def update(self, protocols):
         self.touched = []

--- a/birdwatch
+++ b/birdwatch
@@ -49,6 +49,7 @@ class ProtocolHandler:
     def update(self, protocols):
         self.touched = []
         self.inject_protocols(protocols)
+        self.find_vanished()
         self.alert_for_changes()
 
     def inject_protocol(self, protocol):
@@ -86,16 +87,22 @@ class ProtocolHandler:
         for protocol in protocols:
             self.inject_protocol(protocol)
 
+    def purge_protocol(self, protocol_name):
+        del self.last_state[protocol_name]
+        del self.last_alert_state[protocol_name]
+        del self.alert_time[protocol_name]
+        del self.protocol_log[protocol_name]
+
+    def find_vanished(self):
+        for protocol in self.last_state:
+            if protocol not in self.touched:
+                # Protocol has vanished. Schedule an alert (that will also remove the protocol from our watch).
+                self.last_state[protocol] = 'vanished'
+                self.alert_time[protocol] = datetime.now() + NOTIFICATION_DELAY
+
     def alert_for_changes(self):
         now_x = {}
         body = []
-
-        for protocol in self.last_state:
-            if protocol not in self.touched:
-                # Protocol has vanished. Schedule an alert.
-                self.last_state[protocol] = 'vanished'
-                del self.protocol_log[protocol]
-                self.alert_time[protocol] = datetime.now() + NOTIFICATION_DELAY
 
         for protocol in self.alert_time:
             if self.alert_time[protocol] and self.alert_time[protocol] <= datetime.now():
@@ -112,6 +119,8 @@ class ProtocolHandler:
 
                 if state == 'vanished':
                     body += ['Protocol %s has vanished.' % protocol]
+                    self.purge_protocol(protocol)
+
                 else:
                     proto = self.protocol_log[protocol]
                     body += ['%-15s%-15s%-15s%-15s%-15s'


### PR DESCRIPTION
Fixes #1.

Birdwatch uses multiple arrays to hold information about protocols.
When a protocol vanished, they would be treated inconsistently — birdwatch would attempt to delete it fro `protocol_log` repeatedly (hence the crash), while it would permanently remain in the other arrays.
This changeset makes sure that a vanished protocol is removed from all arrays (and only removed once).